### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/.ensime
+**/.ensime_cache
 
 **/.idea/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/.ensime
+
 **/.idea/
 
 **/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
     on_failure: always
 
 before_install:
-  - bash bin/travis_setup.sh
+  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
 
 script:
   - sbt "aocJVM/testOnly aoc.Day*Spec -- -n aoc.BuildTest"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val sharedSettings = Seq(
   organization := "org.tritsch",
   version := "0.1.0-SNAPSHOT",
 
-  scalaVersion := "2.11.11"
+  scalaVersion in ThisBuild:= "2.11.11"
 )
 
 val jvmSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scala-native" % "sbt-crossproject" % "0.2.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.6")
+addSbtPlugin("org.ensime" % "sbt-ensime" % "2.4.0")


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.